### PR TITLE
Manually map armada-385-linksys-rango -> linksys-wrt3200acm

### DIFF
--- a/distributions/lede/distro_config.yml
+++ b/distributions/lede/distro_config.yml
@@ -16,3 +16,4 @@ board_rename:
   tl-wdr3500: tl-wdr3500-v1
   tl-wdr4300: tl-wdr4300-v1
   tl-wr741: tl-wr741-v1
+  armada-385-linksys-rango: linksys-wrt3200acm

--- a/distributions/openwrt/distro_config.yml
+++ b/distributions/openwrt/distro_config.yml
@@ -17,3 +17,4 @@ board_rename:
   tl-wdr4300: tl-wdr4300-v1
   tl-wr741: tl-wr741-v1
   raspberrypi,3-model-b: rpi-3
+  armada-385-linksys-rango: linksys-wrt3200acm


### PR DESCRIPTION
If I understand well, This is what would be needed to have WRT3200ACM working, fixing https://github.com/aparcar/attendedsysupgrade-server/issues/129