### PR TITLE
distributions: fix typo in targets

### DIFF
--- a/asu/utils/distributions/lime/distro_config.yml
+++ b/asu/utils/distributions/lime/distro_config.yml
@@ -41,9 +41,9 @@ active_targets:
   - mcs814x/generic
   - mpc85xx/generic
   - mpc85xx/p1020
-  - mvevu/cortexa53
-  - mvevu/cortexa72
-  - mvevu/cortexa9
+  - mvebu/cortexa53
+  - mvebu/cortexa72
+  - mvebu/cortexa9
   - octeon/generic
   - ramips/mt7620
   - ramips/mt7621

--- a/asu/utils/distributions/openwrt/distro_config.yml
+++ b/asu/utils/distributions/openwrt/distro_config.yml
@@ -41,9 +41,9 @@ active_targets:
   - mcs814x/generic
   - mpc85xx/generic
   - mpc85xx/p1020
-  - mvevu/cortexa53
-  - mvevu/cortexa72
-  - mvevu/cortexa9
+  - mvebu/cortexa53
+  - mvebu/cortexa72
+  - mvebu/cortexa9
   - octeon/generic
   - oxnas/ox820
   - ramips/mt7620


### PR DESCRIPTION
'mvevu' -> 'mvebu'

Fixes: issue #165 introduced by commit 4667913 "distributions: add common targets"