### PR TITLE
cleanup: "subtarget" separation

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ available devices and more. All responses are in `JSON` format.
 -   `/api/models?distro=&version=&model_search=<search string>` Get all supported
     devices of distro/version that contain the `model_search` string
 
--   `/api/packages_image?distro=&version=&target=&subtarget=&profile=` Get all default
+-   `/api/packages_image?distro=&version=&target=&profile=` Get all default
     packages installed on an image
 
 ### Request stats

--- a/asu/request.py
+++ b/asu/request.py
@@ -52,7 +52,7 @@ class Request:
         self.request["target"] = self.request_json["target"]
 
         # Check if sysupgrade is supported.
-        # If None is returned the subtarget isn't found
+        # If None is returned the target isn't found
         sysupgrade_supported = self.database.sysupgrade_supported(self.request)
         if sysupgrade_supported is None:
             self.response_json["error"] = "unknown target {}".format(

--- a/asu/utils/updater.py
+++ b/asu/utils/updater.py
@@ -32,9 +32,9 @@ class Updater(threading.Thread):
             workers.append(worker)
 
         while True:
-            outdated_subtarget = self.database.get_outdated_target()
-            if outdated_subtarget:
-                log.info("found outdated subtarget %s", outdated_subtarget)
-                self.update_queue.put(outdated_subtarget)
+            outdated_target = self.database.get_outdated_target()
+            if outdated_target:
+                log.info("found outdated target %s", outdated_target)
+                self.update_queue.put(outdated_target)
             else:
                 time.sleep(5)


### PR DESCRIPTION
there was a time when target and subtarget were stored sepparated,
however it's now stored together.

Signed-off-by: Paul Spooren <mail@aparcar.org>