### PR TITLE
Dockerfile: install postgresql-client

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get update -qq &&\
         libssl-dev \
         netcat \
         odbc-postgresql \
+        postgresql-client \
         python2.7 \
         python3 \
         python3-pip \


### PR DESCRIPTION
This is required to use psql from the server/worker image.

Signed-off-by: Paul Spooren <mail@aparcar.org>