### PR TITLE
CI: readme replace badge with gitlab

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Attendedsysupgrade Server for OpenWrt (GSoC 2017)
 
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/d0a6edfd64ef41b6bb44a01ba9b8d7d7)](https://app.codacy.com/app/aparcar/attendedsysupgrade-server?utm_source=github.com&utm_medium=referral&utm_content=aparcar/attendedsysupgrade-server&utm_campaign=Badge_Grade_Dashboard)
-[![Build Status](https://travis-ci.com/aparcar/attendedsysupgrade-server.svg?branch=master)](https://travis-ci.com/aparcar/attendedsysupgrade-server)
+[![pipeline status](https://gitlab.com/aparcar/attendedsysupgrade-server/badges/master/pipeline.svg)](https://gitlab.com/aparcar/attendedsysupgrade-server/commits/master)
 [![PyPI version](https://badge.fury.io/py/asu.svg)](https://badge.fury.io/py/asu)
 [![Docker Pulls](https://img.shields.io/docker/pulls/aparcar/asu-base.svg)](https://cloud.docker.com/repository/docker/aparcar/asu-base)
 


### PR DESCRIPTION
CircleCI is no longer used.

Signed-off-by: Paul Spooren <mail@aparcar.org>